### PR TITLE
add brush slider bar

### DIFF
--- a/demo/static/components/js/main.js
+++ b/demo/static/components/js/main.js
@@ -56,10 +56,11 @@ function ReferenceNameSpace() {
 
             var c = $('.palette-item.selected').data('class');
             if (c != -1) {
+                var brush_size = parseInt($("#ex0").val())
                 var col = s.color(colors[palette.indexOf(c)]);
                 s.mask[palette_selected_index].noStroke();
                 s.mask[palette_selected_index].fill(col);
-                s.mask[palette_selected_index].ellipse(s.mouseX, s.mouseY, 20, 20);
+                s.mask[palette_selected_index].ellipse(s.mouseX, s.mouseY, brush_size, brush_size);
 
             } else { // eraser
                 if (sync_flag == true) {
@@ -347,7 +348,7 @@ $(function () {
         $(".palette-item.selected").removeClass('selected');
         $(this).addClass('selected');
     });
-
+    $('#ex0').slider();
     $('#ex1').slider({
         formatter: function (value) {
             return 'interpolation: ' + (value / (16 - 1)).toFixed(2);
@@ -357,7 +358,7 @@ $(function () {
     $("#ex1").change(function () {
         p5_output.changeCurrentImage(parseInt($("#ex1").val()));
     });
-
+ 
     p5_input_reference = new p5(ReferenceNameSpace(), "p5-reference");
     p5_input_original = new p5(OriginalNameSpace(), "p5-original");
     p5_output = new p5(generateOutputNameSpace(), "p5-right");

--- a/demo/templates/index.html
+++ b/demo/templates/index.html
@@ -11,7 +11,7 @@
             <!-- title -->
             <div class="row" id="title">
                 <h2>
-                    Demo: StyleMapGAN (CVPR21)
+                    Demo: StyleMapGAN (Test)
                 </h2>
             </div>
 
@@ -28,6 +28,10 @@
                     <p> Reference Images / Canvas Draw</p>
                     <div id="p5-reference-wrapper" class="p5-wrapper">
                         <div id="p5-reference" class="p5"></div>
+                    </div>
+                    <div id="result-control" class="row">
+                        <input id="ex0" data-slider-id='ex0Slider' type="text" data-slider-min="0" data-slider-max="100"
+                            data-slider-step="5" data-slider-value="20" />
                     </div>
                     <div id="sketch-control" class="row">
                         <button class="btn btn-danger" id="sketch-clear" disabled>clear canvas and palette</button>


### PR DESCRIPTION
- p5.js는 id를 통해 html 객체에 접근 가능
   - 그래서 <div id = ex0>로 객체를 만들고, main.js에서는 
   - 해당 슬라이더에 해당하는 값은  `parseInt($("#ex0").val())`로 가져와서 brush 사이즈를 변경할 수 있음
- slider에 대한 setting은 index html에서 수정 가능
- 해당 데모는 쿠키를 지워야 변경 사항이 반영 (현재는 매번 그렇게 하는중)
   - 수정 방안을 모색해볼 것 

---

하다보니 orig, ref 이미지를 초기 설정하는 버튼이 직관적이지 못함. 좀 더 직관적인 위치 변경이 필요